### PR TITLE
Fix sqlite3 error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby "3.0.4"
 source 'https://rubygems.org'
 
 gem 'rails', '~> 6.1.7'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.7.3'
 gem 'puma'
 gem 'sass-rails'
 gem 'turbolinks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (2.0.1)
+    sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     strscan (3.1.0)
     temple (0.10.3)
@@ -313,7 +313,7 @@ DEPENDENCIES
   ransack
   rspec-rails
   sass-rails
-  sqlite3
+  sqlite3 (~> 1.7.3)
   tether-rails
   turbolinks
 


### PR DESCRIPTION
```
Failure/Error: ActiveRecord::Migration.maintain_test_schema!

LoadError:
  Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-arm64-darwin. Make sure all dependencies are added to Gemfile.
```